### PR TITLE
Switch from https to git protocol for global optimization-related repos

### DIFF
--- a/CoordinateSplittingPTrees/Package.toml
+++ b/CoordinateSplittingPTrees/Package.toml
@@ -1,3 +1,3 @@
 name = "CoordinateSplittingPTrees"
 uuid = "768c9593-c1e5-5107-8576-9ed3f4373482"
-repo = "https://github.com/timholy/CoordinateSplittingPTrees.jl.git"
+repo = "git@github.com:timholy/CoordinateSplittingPTrees.jl.git"

--- a/HistogramPyramids/Package.toml
+++ b/HistogramPyramids/Package.toml
@@ -1,3 +1,3 @@
 name = "HistogramPyramids"
 uuid = "0f17980a-d2b6-11e8-2799-edcc513b22eb"
-repo = "https://github.com/HolyLab/HistogramPyramids.jl.git"
+repo = "git@github.com:HolyLab/HistogramPyramids.jl.git"

--- a/IntervalFastMath/Package.toml
+++ b/IntervalFastMath/Package.toml
@@ -1,3 +1,3 @@
 name = "IntervalFastMath"
 uuid = "f385d984-c960-11e8-171c-977bba6b62a4"
-repo = "https://github.com/HolyLab/IntervalFastMath.jl.git"
+repo = "git@github.com:HolyLab/IntervalFastMath.jl.git"

--- a/OptimizeIVQ/Package.toml
+++ b/OptimizeIVQ/Package.toml
@@ -1,3 +1,3 @@
 name = "OptimizeIVQ"
 uuid = "7ecfceec-b993-11e8-0809-a584061f8d98"
-repo = "https://github.com/HolyLab/OptimizeIVQ.jl.git"
+repo = "git@github.com:HolyLab/OptimizeIVQ.jl.git"


### PR DESCRIPTION
This is the opposite of #2; perhaps it will help get Travis running on HistogramRegistration (see discussion in https://github.com/HolyLab/HistogramRegistration.jl/pull/1).