### PR TITLE
Switch UnitAliases and ImagineHardware to https urls

### DIFF
--- a/ImagineHardware/Package.toml
+++ b/ImagineHardware/Package.toml
@@ -1,3 +1,3 @@
 name = "ImagineHardware"
 uuid = "75ec5d3c-0ed3-11e9-24c7-e530058603ef"
-repo = "git@github.com:HolyLab/ImagineHardware.jl.git"
+repo = "https://github.com/HolyLab/ImagineHardware.jl.git"

--- a/UnitAliases/Package.toml
+++ b/UnitAliases/Package.toml
@@ -1,3 +1,3 @@
 name = "UnitAliases"
 uuid = "96ae54c0-0dff-11e9-11b2-27e67f6cc5ea"
-repo = "git@github.com:HolyLab/UnitAliases.jl.git"
+repo = "https://github.com/HolyLab/UnitAliases.jl.git"


### PR DESCRIPTION
I think this is needed to avoid credential issues with CI