### PR TITLE
Fix broken registry

### DIFF
--- a/RegisterMismatch/Compat.toml
+++ b/RegisterMismatch/Compat.toml
@@ -2,4 +2,4 @@
 julia = "0.7-1.1"
 
 ["0.2"]
-RegisterMismatchCommon = "0.2"
+RegisterMismatchCommon = "0.2.0"

--- a/RegisterMismatch/Deps.toml
+++ b/RegisterMismatch/Deps.toml
@@ -1,4 +1,4 @@
-["0.0-0.1"]
+["0.0-0.2"]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 CenterIndexedArrays = "46a7138f-0d70-54e1-8ada-fb8296f91f24"
 Images = "916415d5-f1e6-5110-898d-aaa5f9f070e0"

--- a/RegisterMismatch/Versions.toml
+++ b/RegisterMismatch/Versions.toml
@@ -1,8 +1,8 @@
-["0.1.1"]
-git-tree-sha1 = "d58b79b465d512ede82ea178e4695842cb98c07e"
-
 ["0.1.0"]
 git-tree-sha1 = "10af7bad79c2e6915851edbc260bafee5126d9b1"
+
+["0.1.1"]
+git-tree-sha1 = "d58b79b465d512ede82ea178e4695842cb98c07e"
 
 ["0.2.0"]
 git-tree-sha1 = "abdae245bf6a6d932fc02ffb6f5f701a9d191503"


### PR DESCRIPTION
So, it turns out that when you start applying minimum bounds in `[compat]` sections, you have to look very carefully at the `Deps.toml` file and make sure that the range includes the new package version. :cry: 