### PR TITLE
rename to ImagineInterface.jl

### DIFF
--- a/ImagineInterface/Package.toml
+++ b/ImagineInterface/Package.toml
@@ -1,3 +1,3 @@
 name = "ImagineInterface"
 uuid = "a9d8408c-0fb1-11e9-0067-cb067474114e"
-repo = "https://github.com/HolyLab/ImagineInterface.git"
+repo = "https://github.com/HolyLab/ImagineInterface.jl.git"


### PR DESCRIPTION
I renamed the repo to match the .jl naming convention.  I'll probably do the same with others soon.