### PR TITLE
Fix unquoted UUID in Imagine/Versions.toml

### DIFF
--- a/Imagine/Versions.toml
+++ b/Imagine/Versions.toml
@@ -1,5 +1,5 @@
 ["0.1.0"]
-git-tree-sha1 = 63569bcc258093288ccd40f46b612862ea4c4930
+git-tree-sha1 = "63569bcc258093288ccd40f46b612862ea4c4930"
 
 ["0.1.1"]
-git-tree-sha1 = 5230ec86f0d2f114a86265dcc168b978f1d8c0e8
+git-tree-sha1 = "5230ec86f0d2f114a86265dcc168b978f1d8c0e8"


### PR DESCRIPTION
I think this was my fault, some time ago I must have left the quotes out from a UUID in Imagine/Versions.toml