### PR TITLE
Make HolyLabRegistry a valid package, test with Travis that all .toml…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+## Documentation: http://docs.travis-ci.com/user/languages/julia/
+language: julia
+os:
+  - linux
+  - osx
+julia:
+  - 1.1
+notifications:
+  email: false
+git:
+  depth: 99999999
+
+## uncomment the following lines to allow failures on nightly julia
+## (tests will run but not make your overall status red)
+#matrix:
+#  allow_failures:
+#  - julia: nightly
+
+## uncomment and modify the following lines to manually install system packages
+addons:
+  apt:
+    packages:
+      - build-essential
+      - gfortran
+      - pkg-config
+      - hdf5-tools
+
+## uncomment the following lines to override the default test script
+script:
+  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+  - julia -e 'using Pkg; Pkg.build(); Pkg.test("HolyLabRegistry"; coverage=true)'

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,0 +1,51 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[LibGit2]]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[Pkg]]
+deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,16 @@
+name = "HolyLabRegistry"
+uuid = "60d581ba-a110-11e9-1ea8-7112b44139e2"
+authors = ["Cody-G <codyjgreer@gmail.com>"]
+version = "0.1.0"
+
+[deps]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[compat]
+julia = "1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/src/HolyLabRegistry.jl
+++ b/src/HolyLabRegistry.jl
@@ -1,0 +1,3 @@
+#dummy file to get test to run with CI
+module HolyLabRegistry
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,21 @@
+using Pkg.TOML
+using Test
+
+d = @__DIR__
+cd(d*"/..")
+
+contents = readdir()
+for c in contents
+    if isdir(c)
+        print("Entering $c\n")
+        cd(c)
+        files = readdir(".")
+        for f in files
+            if splitext(f)[2] == ".toml"
+                print("parsing $f\n")
+                @test_nowarn TOML.parsefile(f)
+            end
+        end
+        cd("..")
+    end
+end


### PR DESCRIPTION
… files can be parsed without error

This may be a bit unorthodox so I would appreciate hearing others' opinions before merging.  The benefit of this change is that when we make a PR to the registry we can run Travis tests to make sure that the changes don't corrupt any .toml files.  At the moment I'm just checking whether `TOML.parsefile` fails.  This is enough to catch and prevent mysterious errors due to failed parsing (see https://github.com/JuliaLang/Pkg.jl/issues/1017).

@timholy and @kdw503 does this look good to you?