### PR TITLE
New version: RegisterQD v0.2.0

### DIFF
--- a/RegisterQD/Deps.toml
+++ b/RegisterQD/Deps.toml
@@ -1,8 +1,10 @@
-["0.0-0.2"]
+["0.1"]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+["0.1-0.2"]
 CenterIndexedArrays = "46a7138f-0d70-54e1-8ada-fb8296f91f24"
 CoordinateTransformations = "150eb455-5306-5404-9cee-2592286d6298"
 Images = "916415d5-f1e6-5110-898d-aaa5f9f070e0"
@@ -14,3 +16,6 @@ RegisterDeformation = "c19381b7-cf49-59d7-881c-50dfbd227eaf"
 RegisterMismatch = "3c0dd727-6833-5f5d-a1e8-c0d421935c74"
 Rotations = "6038ab10-8711-5258-84ad-4b1120ba62dc"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+
+["0.2"]
+OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"

--- a/RegisterQD/Versions.toml
+++ b/RegisterQD/Versions.toml
@@ -1,2 +1,5 @@
 ["0.1.0"]
 git-tree-sha1 = "d66246d1e06fc6e330ffc3f479c24189e2d1e3e8"
+
+["0.2.0"]
+git-tree-sha1 = "7b96c28c5d7ee67786e5ff8b843be36ea62d2f29"


### PR DESCRIPTION
UUID: ac24ea0c-1830-11e9-18d4-81f172323054
Repo: git@github.com:HolyLab/RegisterQD.jl.git
Tree: 7b96c28c5d7ee67786e5ff8b843be36ea62d2f29

Thanks to @ChantalJuntao for lots of work on this release!