### PR TITLE
New version: RegisterCore v0.2.0

### DIFF
--- a/RegisterCore/Compat.toml
+++ b/RegisterCore/Compat.toml
@@ -1,2 +1,8 @@
-["0.1"]
+["0-0.1"]
 julia = "0.7-1"
+
+["0.2-0"]
+CenterIndexedArrays = "0.1-0.2"
+ImageCore = "0.8.1-0.8"
+ImageFiltering = "0.5-0.6"
+julia = "1.1.0-1"

--- a/RegisterCore/Deps.toml
+++ b/RegisterCore/Deps.toml
@@ -1,8 +1,14 @@
-["0.0-0.1"]
+[0]
+CenterIndexedArrays = "46a7138f-0d70-54e1-8ada-fb8296f91f24"
+
+["0-0.1"]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
+Images = "916415d5-f1e6-5110-898d-aaa5f9f070e0"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-CenterIndexedArrays = "46a7138f-0d70-54e1-8ada-fb8296f91f24"
-ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
-Images = "916415d5-f1e6-5110-898d-aaa5f9f070e0"
+
+["0.2-0"]
+ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
+ImageFiltering = "6a3955dd-da59-5b1f-98d4-e7296123deb5"

--- a/RegisterCore/Package.toml
+++ b/RegisterCore/Package.toml
@@ -1,3 +1,4 @@
+authors = ["Tim Holy <tim.holy@gmail.com>"]
 name = "RegisterCore"
 uuid = "67712758-55e7-5c3c-8e85-dda1d7758434"
 repo = "https://github.com/HolyLab/RegisterCore.jl.git"

--- a/RegisterCore/Versions.toml
+++ b/RegisterCore/Versions.toml
@@ -3,3 +3,6 @@ git-tree-sha1 = "b6f09f115abe356f3fa346bc071230bfff32d27e"
 
 ["0.1.1"]
 git-tree-sha1 = "99fa9e55f70ff66f338898c3f4948b462ea3f240"
+
+["0.2.0"]
+git-tree-sha1 = "f4056fb4503b46a9c7fd8f53c9f019f18e62d7c9"


### PR DESCRIPTION
UUID: 67712758-55e7-5c3c-8e85-dda1d7758434
Repo: git@github.com:HolyLab/RegisterCore.jl.git
Tree: f4056fb4503b46a9c7fd8f53c9f019f18e62d7c9

This supersedes #97