### PR TITLE
New version: BlockRegistration v0.2.2

### DIFF
--- a/B/BlockRegistration/Versions.toml
+++ b/B/BlockRegistration/Versions.toml
@@ -1,2 +1,5 @@
 ["0.2.0"]
 git-tree-sha1 = "ffd9bc35e71112d0705d341962a76d1480cc6589"
+
+["0.2.2"]
+git-tree-sha1 = "e7b968e68491a7e441f75fb6da6e4e1e8ef8f9f8"


### PR DESCRIPTION
UUID: 96be3cfc-dfc9-41f0-9424-fd41ed36fd5e
Repo: git@github.com:HolyLab/BlockRegistration.jl.git
Tree: e7b968e68491a7e441f75fb6da6e4e1e8ef8f9f8