### PR TITLE
New version: RegisterDriver v0.2.0

### DIFF
--- a/RegisterDriver/Compat.toml
+++ b/RegisterDriver/Compat.toml
@@ -1,2 +1,13 @@
-["0.1"]
+["0-0.1"]
 julia = "0.7-1"
+
+["0.2-0"]
+Formatting = "0.4"
+HDF5 = "0.12"
+ImageCore = "0.8.1-0.8"
+ImageMetadata = "0.9"
+JLD = "0.9"
+RegisterCore = "0.2"
+RegisterWorkerShell = "0.2"
+StaticArrays = "0.11-0.12"
+julia = "1"

--- a/RegisterDriver/Deps.toml
+++ b/RegisterDriver/Deps.toml
@@ -1,15 +1,21 @@
-["0.0-0.1"]
-Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
-InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
+[0]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 Formatting = "59287772-0a20-5a39-b81b-1366585eb4c0"
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
-Images = "916415d5-f1e6-5110-898d-aaa5f9f070e0"
 JLD = "4138dd39-2aa7-5051-a626-17a0bb65d9c8"
 RegisterCore = "67712758-55e7-5c3c-8e85-dda1d7758434"
 RegisterWorkerShell = "978d31ce-2656-11e9-22d6-b5c46a1a3d3e"
 SharedArrays = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+
+["0-0.1"]
+Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
+Images = "916415d5-f1e6-5110-898d-aaa5f9f070e0"
+InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+["0.2-0"]
+ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
+ImageMetadata = "bc367c6b-8a6b-528e-b4bd-a4b897500b49"

--- a/RegisterDriver/Versions.toml
+++ b/RegisterDriver/Versions.toml
@@ -1,2 +1,5 @@
 ["0.1.0"]
 git-tree-sha1 = "b23e805a4f31180da87704cf01cfb5c0e1667ac9"
+
+["0.2.0"]
+git-tree-sha1 = "1319ebf9959da018d8480963fd770eee954bdb2f"


### PR DESCRIPTION
UUID: 935ac36e-2656-11e9-1e3b-cbaa636797af
Repo: git@github.com:HolyLab/RegisterDriver.jl.git
Tree: 1319ebf9959da018d8480963fd770eee954bdb2f