### PR TITLE
New version: RegisterDriver v0.2.1

### DIFF
--- a/RegisterDriver/Versions.toml
+++ b/RegisterDriver/Versions.toml
@@ -3,3 +3,6 @@ git-tree-sha1 = "b23e805a4f31180da87704cf01cfb5c0e1667ac9"
 
 ["0.2.0"]
 git-tree-sha1 = "1319ebf9959da018d8480963fd770eee954bdb2f"
+
+["0.2.1"]
+git-tree-sha1 = "ed6aeed2397caf174ce0a95057040c58d4f48301"


### PR DESCRIPTION
UUID: 935ac36e-2656-11e9-1e3b-cbaa636797af
Repo: git@github.com:HolyLab/RegisterDriver.jl.git
Tree: ed6aeed2397caf174ce0a95057040c58d4f48301