### PR TITLE
New version: QuadDIRECT v0.1.1

### DIFF
--- a/QuadDIRECT/Compat.toml
+++ b/QuadDIRECT/Compat.toml
@@ -1,0 +1,4 @@
+["0.1.1-0"]
+PositiveFactorizations = "0.2"
+StaticArrays = "0.10-0.12"
+julia = "1"

--- a/QuadDIRECT/Deps.toml
+++ b/QuadDIRECT/Deps.toml
@@ -1,10 +1,10 @@
+[0]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+PositiveFactorizations = "85a6dd25-e78a-55b7-8502-1745935b8125"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+
 ["0.0"]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-["0.0-0.1"]
-LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-PositiveFactorizations = "85a6dd25-e78a-55b7-8502-1745935b8125"
-StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"

--- a/QuadDIRECT/Versions.toml
+++ b/QuadDIRECT/Versions.toml
@@ -3,3 +3,6 @@ git-tree-sha1 = "f58be6b86d40ea6aa198a8ad009140114dfb5857"
 
 ["0.1.0"]
 git-tree-sha1 = "134c19d9fcfe3c574e8868c4f6760fa90d98a794"
+
+["0.1.1"]
+git-tree-sha1 = "1cbf082a8b43872df60b9ef36cf5dbd666984689"


### PR DESCRIPTION
UUID: dae52e8d-d666-5120-a592-9e15c33b8d7a
Repo: git@github.com:timholy/QuadDIRECT.jl.git
Tree: 1cbf082a8b43872df60b9ef36cf5dbd666984689