### PR TITLE
Create TriggerTagBot.yml

### DIFF
--- a/.github/workflows/TriggerTagBot.yml
+++ b/.github/workflows/TriggerTagBot.yml
@@ -1,0 +1,24 @@
+
+name: TriggerTagBot
+on:
+  push:
+    branches:
+      - master
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+      - name: Get updated package name
+        id: pkg
+        run: |
+          PACKAGENAME=$(git diff HEAD^ --stat | grep /Versions.toml | cut -d/ -f2 | uniq)
+          echo "::set-output name=packagename::$PACKAGENAME"
+      - name: Run `repository_dispatch` on updated repo, to trigger tagbot
+        run: |
+          curl -X POST https://api.github.com/repos/HolyLab/${{ steps.pkg.outputs.packagename }}.jl/dispatches \
+          -H 'Accept: application/vnd.github.everest-preview+json' \
+          -u ${{ secrets.PERSONAL_ACCESS_TOKEN }} \
+          --data '{"event_type": "TriggerTagBot_${{ steps.pkg.outputs.packagename }}", "client_payload": { "repository": "'"$GITHUB_REPOSITORY"'" }}'

--- a/.github/workflows/TriggerTagBot.yml
+++ b/.github/workflows/TriggerTagBot.yml
@@ -20,5 +20,5 @@ jobs:
         run: |
           curl -X POST https://api.github.com/repos/HolyLab/${{ steps.pkg.outputs.packagename }}.jl/dispatches \
           -H 'Accept: application/vnd.github.everest-preview+json' \
-          -u ${{ secrets.PERSONAL_ACCESS_TOKEN }} \
+          -u ${{ secrets.DOCUMENTER_KEY }} \
           --data '{"event_type": "TriggerTagBot_${{ steps.pkg.outputs.packagename }}", "client_payload": { "repository": "'"$GITHUB_REPOSITORY"'" }}'


### PR DESCRIPTION
This will run on every push to master, and will trigger any TagBots on repos where new releases are found.

Requires:

- Each TagBot.yml on the repos to have `repository_dispatch` listed. Edit: Example PR here https://github.com/HolyLab/RegisterMismatchCommon.jl/pull/9
- `secrets.PERSONAL_ACCESS_TOKEN` to be available. I wasn't sure what that was called for this org. Edit: I guessed DOCUMENTER_KEY has the necessary permissions already so used that