### PR TITLE
Updated Compat and Git Tree Version for  RegisterPenalty v0.3.0

### DIFF
--- a/R/RegisterPenalty/Compat.toml
+++ b/R/RegisterPenalty/Compat.toml
@@ -20,6 +20,8 @@ RegisterUtilities = "0.1"
 StaticArrays = "0.10-0.12"
 
 ["0.3-0"]
+CoordinateTransformations = "0.5-0.6"
 Interpolations = "0.9-0.13"
 RegisterDeformation = "0.3-0.4"
+StaticArrays = "0.10-1"
 julia = "1.6.0-1"

--- a/R/RegisterPenalty/Versions.toml
+++ b/R/RegisterPenalty/Versions.toml
@@ -5,4 +5,4 @@ git-tree-sha1 = "49da44164437d2292b25ce27fa7e34f00a8a58d3"
 git-tree-sha1 = "095ddd18425aed727c9f88dc83e21d8026802b63"
 
 ["0.3.0"]
-git-tree-sha1 = "b0c516a8801f8d43687752597997afc4f359e25f"
+git-tree-sha1 = "5ca2bb8881eaa5f0be975b359c4961b6f17112cc"


### PR DESCRIPTION
I tried to update this manually. 

git cat-file -p v0.3.0 didn't work on my machine for some reason, so I pulled the most recent origin/master from RegisterPenalty and got the sha from git cat-file -p master. 