### PR TITLE
Fix tree-hash for RegisterQD 0.3.2

### DIFF
--- a/R/RegisterQD/Versions.toml
+++ b/R/RegisterQD/Versions.toml
@@ -32,4 +32,4 @@ git-tree-sha1 = "340009a0b8d457a7163183c4d28e7c5606bf7e06"
 git-tree-sha1 = "a43b8a3d16fad1f52f3cf28ffa03200007297fa2"
 
 ["0.3.2"]
-git-tree-sha1 = "bf74d7ddd3d103734e54c6c96fac265ab3d20f69"
+git-tree-sha1 = "b20baa693ae94505a7be4d2a1271f26507d5be76"


### PR DESCRIPTION
Noticed while looking at https://github.com/HolyLab/RegisterQD.jl/issues/51