### PR TITLE
Redo BoxTrees 1.0

### DIFF
--- a/B/BoxTrees/Versions.toml
+++ b/B/BoxTrees/Versions.toml
@@ -12,6 +12,3 @@ git-tree-sha1 = "a59170813f11344d8c6c571036514a8d377a095c"
 
 ["0.0.5"]
 git-tree-sha1 = "3c6c9a7816485faa26fabb25caf12df644fd7190"
-
-["1.0.0"]
-git-tree-sha1 = "7dbb9d4a825d694d466d81499ef0e396a66a5048"

--- a/B/BoxTrees/Versions.toml
+++ b/B/BoxTrees/Versions.toml
@@ -12,3 +12,6 @@ git-tree-sha1 = "a59170813f11344d8c6c571036514a8d377a095c"
 
 ["0.0.5"]
 git-tree-sha1 = "3c6c9a7816485faa26fabb25caf12df644fd7190"
+
+["1.0.0"]
+git-tree-sha1 = "e17649c35f3e9a58f257c7e9244bd73f3d807459"


### PR DESCRIPTION
I regret not making a few more breaking changes to BoxTrees before going to 1.0. Since nothing else that depends on it has been upgraded yet, we can just redo it.