### PR TITLE
Fix TriggerTagBot to handle multi-package registration PRs

### DIFF
--- a/.github/workflows/TriggerTagBot.yml
+++ b/.github/workflows/TriggerTagBot.yml
@@ -12,26 +12,26 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 2
-      - name: Get updated package name
-        id: pkg
-        run: |
-          PACKAGENAME=$(git diff HEAD^ --stat | grep /Versions.toml | cut -d/ -f2 | uniq)
-          echo "Package name is: $PACKAGENAME"
-          echo "packagename=$PACKAGENAME" >> "$GITHUB_ENV"
-      - name: Run `repository_dispatch` on updated repo, to trigger tagbot
+      - name: Trigger TagBot for each updated package
         env:
           TAGBOT_PAT: ${{ secrets.TAGBOT_TOKEN }}
         run: |
-          if [ -z "$packagename" ]; then
+          PACKAGENAMES=$(git diff HEAD^ --stat | grep /Versions.toml | cut -d/ -f2 | sort -u)
+          if [ -z "$PACKAGENAMES" ]; then
             echo "No package name detected, skipping dispatch"
             exit 0
           fi
-          echo "Triggering TagBot for: $packagename"
+          echo "Package names:"
+          echo "$PACKAGENAMES"
           payload=$(printf '{"event_type":"TagBot","client_payload":{"repository":"%s"}}' "$GITHUB_REPOSITORY")
-          curl --http1.1 -X POST \
-            "https://api.github.com/repos/HolyLab/${packagename}.jl/dispatches" \
-            -H 'Accept: application/vnd.github.everest-preview+json' \
-            -H "Authorization: Bearer $TAGBOT_PAT" \
-            -H 'Content-Type: application/json' \
-            --verbose \
-            --data "$payload"
+          while IFS= read -r packagename; do
+            [ -z "$packagename" ] && continue
+            echo "Triggering TagBot for: $packagename"
+            curl --http1.1 -X POST \
+              "https://api.github.com/repos/HolyLab/${packagename}.jl/dispatches" \
+              -H 'Accept: application/vnd.github.everest-preview+json' \
+              -H "Authorization: Bearer $TAGBOT_PAT" \
+              -H 'Content-Type: application/json' \
+              --verbose \
+              --data "$payload"
+          done <<< "$PACKAGENAMES"


### PR DESCRIPTION
A registration PR that updates multiple packages' Versions.toml files (e.g. HolyLab/HolyLabRegistry#352, which registered TileTrees 1.4 and TiledFactorizations 1.0 together) made `PACKAGENAME` a multiline value. Writing a multiline string to $GITHUB_ENV without heredoc syntax fails with `Invalid format`, so the step errored out and no `repository_dispatch` was sent — leaving TiledFactorizations v1.0.0 untagged.

Loop over package names within a single step instead, and dispatch once per package.